### PR TITLE
Dependency reviewer

### DIFF
--- a/.github/workflows/dependency_enforcement.yml
+++ b/.github/workflows/dependency_enforcement.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v2
         with:
-          fail-on-severity: high
+          fail-on-severity: low
           fail-on-scopes: runtime, development


### PR DESCRIPTION
This PR enables the Dependency Reviewer in your repository. It also to prevents vulnerable dependencies from reaching out your codebase. In most cases you will be able to merge this PR as is and start benefiting from its features right away, as a check in each PR. 
However, we encourage you to tag @Malwarebytes/security-appsec (or `#github-appsec-security` on Slack) if you have any questions.

We are here to help! :thumbsup:

 - Application Security team.