### PR TITLE
Rename CodeQL workflows by language

### DIFF
--- a/templates/codeql-analysis-default.yml
+++ b/templates/codeql-analysis-default.yml
@@ -6,7 +6,7 @@
 #
 # Reach out on Slack at '#github-appsec-security' to get help.
 
-name: "CodeQL"
+name: "CodeQL - Default"
 
 on:
   push:

--- a/templates/codeql-analysis-javascript.yml
+++ b/templates/codeql-analysis-javascript.yml
@@ -6,7 +6,7 @@
 #
 # Reach out on Slack at '#github-appsec-security' to get help.
 
-name: "CodeQL"
+name: "CodeQL - Javascript"
 
 on:
   push:

--- a/templates/codeql-analysis-python.yml
+++ b/templates/codeql-analysis-python.yml
@@ -6,7 +6,7 @@
 #
 # Reach out on Slack at '#github-appsec-security' to get help.
 
-name: "CodeQL"
+name: "CodeQL - Python"
 
 on:
   push:

--- a/templates/codeql-analysis-ruby.yml
+++ b/templates/codeql-analysis-ruby.yml
@@ -6,7 +6,7 @@
 #
 # Reach out on Slack at '#github-appsec-security' to get help.
 
-name: "CodeQL"
+name: "CodeQL - Ruby"
 
 on:
   push:


### PR DESCRIPTION
Avoid having multiple workflows named `CodeQL` in Actions.