### PR TITLE
Pass X-GitHub-Api-Version header to use the new calendar versioning

### DIFF
--- a/src/ghas_cli/utils/network.py
+++ b/src/ghas_cli/utils/network.py
@@ -21,6 +21,7 @@ def get_github_headers(token: str) -> Dict:
         "accept": "application/vnd.github+json",
         "authorization": f"Bearer {token}",
         "User-Agent": "malwarebytes/bulk_enable_ghas",
+        "X-GitHub-Api-Version": "2022-11-28",  # https://docs.github.com/en/rest/overview/api-versions#supported-api-versions
     }
 
 


### PR DESCRIPTION
See
* https://docs.github.com/en/rest/overview/breaking-changes?apiVersion=2022-11-28
* https://github.blog/changelog/2022-11-28-calendar-based-versioning-for-the-rest-api/

Close #58