### PR TITLE
fix: correct type hints and undefined variable in utils

### DIFF
--- a/src/ghas_cli/utils/export.py
+++ b/src/ghas_cli/utils/export.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+from typing import Dict
 
 
 def output_to_csv(alerts_per_repos: Dict, location: str) -> bool:

--- a/src/ghas_cli/utils/network.py
+++ b/src/ghas_cli/utils/network.py
@@ -57,7 +57,7 @@ def check_unauthorized(response: Any):
     return True
 
 
-def check_response(response: any):
+def check_response(response: Any):
     check_rate_limit(response)
     check_unauthorized(response)
 

--- a/src/ghas_cli/utils/roles.py
+++ b/src/ghas_cli/utils/roles.py
@@ -24,7 +24,7 @@ def create_role(
     }
 
     role_resp = requests.post(
-        url=f"https://api.github.com/orgs/{organization}/custom_roles",
+        url=f"https://api.github.com/orgs/{org}/custom_roles",
         headers=headers,
         json=payload,
     )


### PR DESCRIPTION
## Summary

Fix 3 bugs across 3 files:

- `src/ghas_cli/utils/network.py`: Use `Any` (typing) instead of `any` (builtin) in `check_response` type hint
- `src/ghas_cli/utils/roles.py`: Fix undefined `organization` variable to use `org` parameter in `create_role()`
- `src/ghas_cli/utils/export.py`: Add missing `from typing import Dict` import used in function signature

These are functional fixes — `any` vs `Any` is a type-hint bug, the `organization` reference would cause a `NameError` at runtime, and the missing `Dict` import would also cause a `NameError`.